### PR TITLE
Fix identifier name in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ void main() {
   vec3 lightDirection = normalize(lightPosition - surfacePosition);
   vec3 normal = normalize(surfaceNormal);
 
-  float power = blinnPhongSpec(lightDirection, viewDirection, normal, shininess);
+  float power = blinnPhongSpec(lightDirection, eyeDirection, normal, shininess);
 
   gl_FragColor = vec4(power,power,power,1.0);
 }


### PR DESCRIPTION
In the example, the 'blinnPhongSpec' function is called with the undeclared 'viewDirection' variable as its second argument (this is is also the name of the function's second formal parameter). The corresponding variable in the example is named 'eyeDirection'. This commit fixes the referrence.
